### PR TITLE
Tries to add named arguments to snippet files (might be impossible).

### DIFF
--- a/lib/Scandio/lmvc/modules/snippets/SnippetHandler.php
+++ b/lib/Scandio/lmvc/modules/snippets/SnippetHandler.php
@@ -17,6 +17,7 @@ abstract class SnippetHandler
      * used to include the snippets - behaviour may be overridden by private or public static functions
      *
      * @static
+     *
      * @param string $name camelCasedName of the snippet
      * @param array $params parameters passed to the snippet
      * @return mixed|string the result of your private static function, an ErrorMessage or just an empty string

--- a/lib/Scandio/lmvc/modules/snippets/SnippetHandler.php
+++ b/lib/Scandio/lmvc/modules/snippets/SnippetHandler.php
@@ -32,6 +32,19 @@ abstract class SnippetHandler
             if (self::$snippetFile) {
                 $app = LVC::get(); // should be available in the snippet's scope as in views for convenience
                 include(self::$snippetFile);
+
+                # makes sure defaults are an array even if they're nulled
+                $snippetDefaults = (array) $snippetDefaults;
+
+                if (is_array($params[0])) {
+                    # merge defaults with actual
+                    $params = array_merge($snippetDefaults, $params[0]);
+
+                    # make $params available by extracting them globally
+                    extract($params);
+                }
+
+                # AND NOW I AM SCREWED AS I CAN'T INJECT THE EXTRACT INTO THE INCLUDE AGAIN...
             } elseif (preg_match('/^get[A-Z]/', $name)) {
                 ob_start();
                 echo static::__callStatic(lcfirst(substr($name, 3)), $params);


### PR DESCRIPTION
Snippets currently allow easy reusability of small html snippets. Snippets are located under a named path and loaded in by extending the `SnippetHandler` so that e.g. `UI::css(...)` loads the css snippet within the snippet handlers directory with the name `css.html`.
# Checklist
- [x] Understand the magic (`__callStatic`) [here](https://github.com/SEP007/lmvc-modules/blob/master/lib/Scandio/lmvc/modules/snippets/SnippetHandler.php)
  - Well, it's not magic just PHP
- [ ] Evaluate possible solutions
- [ ] Decide on implementation
